### PR TITLE
[PAGOPA-957] fix: resolved bug on Oracle DB connectivity

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pagopa-api-config-selfcare-integration
 description: Microservice that manages requests from selfcare
 type: application
-version: 1.0.12
+version: 1.0.13
 appVersion: 1.1.0
 dependencies:
   - name: microservice-chart

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -3,7 +3,7 @@ name: pagopa-api-config-selfcare-integration
 description: Microservice that manages requests from selfcare
 type: application
 version: 1.0.13
-appVersion: 1.1.0
+appVersion: 1.1.1
 dependencies:
   - name: microservice-chart
     version: 1.21.0

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -84,4 +84,4 @@ microservice-chart:
   canaryDelivery:
     deployment:
       image:
-        tag: 1.1.0
+        tag: 1.1.0-1-PAGOPA-957-bug-connettivita-db-oracle

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-api-config-selfcare-integration
-    tag: "1.1.0"
+    tag: "1.1.1"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -84,4 +84,4 @@ microservice-chart:
   canaryDelivery:
     deployment:
       image:
-        tag: 1.1.0
+        tag: 1.1.0-1-PAGOPA-957-bug-connettivita-db-oracle

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-api-config-selfcare-integration
-    tag: "1.1,0"
+    tag: "1.1.1"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -84,4 +84,4 @@ microservice-chart:
   canaryDelivery:
     deployment:
       image:
-        tag: 1.1.0
+        tag: 1.1.0-1-PAGOPA-957-bug-connettivita-db-oracle

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-api-config-selfcare-integration
-    tag: "1.1,0"
+    tag: "1.1.1"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "description": "Spring application exposes APIs for SelfCare",
     "termsOfService": "https://www.pagopa.gov.it/",
     "title": "API-Config - SelfCare Integration",
-    "version": "1.1.0"
+    "version": "1.1.0-1-PAGOPA-957-bug-connettivita-db-oracle"
   },
   "servers": [
     {

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>it.gov.pagopa.api-config</groupId>
   <artifactId>selfcareintegration</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.0-1-PAGOPA-957-bug-connettivita-db-oracle</version>
   <name>API-Config - SelfCare Integration</name>
   <description>Spring application exposes APIs for SelfCare</description>
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,4 +36,5 @@ spring.jpa.properties.hibernate.default_schema=${DATABASE_SCHEMA}
 
 # HikariCP configuration
 spring.datasource.hikari.connection-timeout=15000
+spring.datasource.hikari.maxLifetime=30000
 


### PR DESCRIPTION
With this commit, it was resolved a bug on which the application reused an expired connection from HikariCP. This was caused by a difference between the Hikari `maxLifetime` duration (that define the connection TTL) and the Oracle connection lifetime. The bugfix is applied adding a new configuration parameter in order to explicitely set the `maxLifetime` parameter. 

##### Note:
Due to a bug on release's GitHub pipeline, the Helm Chart versioning is made by hand.

#### List of Changes
 - Added new parameter for set Hikari connection lifetime

#### Motivation and Context
This change is required in order to resolve the connectivity issue towards DB.

#### How Has This Been Tested?
 - Tested in dev environment

#### Screenshots (if appropriate):

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
